### PR TITLE
Import simulation helper in world clock

### DIFF
--- a/src/modules/world/worldClock.ts
+++ b/src/modules/world/worldClock.ts
@@ -1,6 +1,7 @@
 // src/modules/world/worldClock.ts
 
 import { PrismaClient } from "@prisma/client";
+import { simulateTimePassed } from "../simulation/simulateTimePassed";
 
 const prisma = new PrismaClient();
 


### PR DESCRIPTION
## Summary
- import the world simulation helper into the world clock module so the call is defined

## Testing
- npx tsc --noEmit src/modules/world/worldClock.ts *(fails: requires ES2015 lib configuration and other project type definitions)*

------
https://chatgpt.com/codex/tasks/task_e_68cd37ac83148322a654a47c17693458