### PR TITLE
Add generateBountyQuest import to reputation service

### DIFF
--- a/src/modules/reputation/reputationService.ts
+++ b/src/modules/reputation/reputationService.ts
@@ -1,6 +1,7 @@
 // src/modules/reputation/reputationService.ts
 
 import { PrismaClient } from "@prisma/client";
+import { generateBountyQuest } from "../quest/generateBountyQuest";
 
 const prisma = new PrismaClient();
 


### PR DESCRIPTION
## Summary
- add the missing `generateBountyQuest` import to the reputation service so high notoriety users can trigger bounty generation

## Testing
- `npx tsc --noEmit src/modules/reputation/reputationService.ts` *(fails: requires newer lib targets and missing module resolution in existing code)*
- `npm run lint` *(fails: Missing script "lint")*
- `npm run build` *(fails: Missing script "build")*

------
https://chatgpt.com/codex/tasks/task_e_68cd37d30b6083228bfb79da30717e20