### PR TITLE
Instantiate PrismaClient in NPC chat handler

### DIFF
--- a/npcChatHandler.tsx
+++ b/npcChatHandler.tsx
@@ -1,6 +1,9 @@
 // npcChatHandler.ts
 
-import { getNobleDialog } from "../dialog/nobleDialog";
+import { PrismaClient } from "@prisma/client";
+import { getNobleDialog } from "./src/modules/dialog/nobleDialog";
+
+const prisma = new PrismaClient();
 
 export async function handleNobleInteraction(nobleId: number, userId: number) {
   const noble = await prisma.nPC.findUnique({ where: { id: nobleId } });


### PR DESCRIPTION
## Summary
- import PrismaClient in `npcChatHandler.tsx` and instantiate a local client for queries
- update the noble dialog import to reference the module under `src/modules/dialog`

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cd37d460b483228308a206b2d5a1ec